### PR TITLE
4 código de erro

### DIFF
--- a/core/MathExpress.f90
+++ b/core/MathExpress.f90
@@ -258,7 +258,7 @@ contains
 
     if (.not.associated(self%head))then
        print*,trim(myname_)//' :: error : not initialized ...'
-       stop -33
+       stop 99032
 !       call self%initialize()
     endif
 
@@ -477,7 +477,7 @@ contains
 
     if (.not.associated(self%head))then
        print*,trim(myname_)//' :: error : not initialized ...'
-       stop -34
+       stop 99033
 !       call self%initialize()
     endif
    
@@ -597,7 +597,7 @@ contains
 
     if (.not.associated(self%head))then
        print*,trim(myname_)//' :: error : not initialized ...'
-       stop -35
+       stop 99034
 !       call self%initialize()
     endif
    

--- a/core/MathExpress.f90
+++ b/core/MathExpress.f90
@@ -258,7 +258,7 @@ contains
 
     if (.not.associated(self%head))then
        print*,trim(myname_)//' :: error : not initialized ...'
-       stop
+       stop -33
 !       call self%initialize()
     endif
 
@@ -477,7 +477,7 @@ contains
 
     if (.not.associated(self%head))then
        print*,trim(myname_)//' :: error : not initialized ...'
-       stop
+       stop -34
 !       call self%initialize()
     endif
    
@@ -597,7 +597,7 @@ contains
 
     if (.not.associated(self%head))then
        print*,trim(myname_)//' :: error : not initialized ...'
-       stop
+       stop -35
 !       call self%initialize()
     endif
    

--- a/core/m_inpak90.F90
+++ b/core/m_inpak90.F90
@@ -3113,7 +3113,7 @@ end subroutine perr4_
   msg = char(27)//'[31;1m'//trim(where)//char(27)//'[m'
   write(stdout,'(A)')trim(msg)
 
-  stop
+  stop 99035
   
 end subroutine die0_
 
@@ -3155,7 +3155,7 @@ end subroutine die0_
 
   write(stdout,'(A)')trim(msg)
 
-  stop
+  stop 99036
   
 end subroutine die2_
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3195,7 +3195,7 @@ end subroutine die2_
    mesg2,'=',trim(adjustl(cval2)),'.'
 
   write(stdout,'(A)')trim(msg)
-  stop
+  stop 99038
 
 end subroutine die4_
 

--- a/core/scan_ModelPlugin.f90
+++ b/core/scan_ModelPlugin.f90
@@ -196,13 +196,13 @@ Contains
       if(.not.found)then
          write(msg,'(2A)')'File not found :', trim(fileModelConf)
          call i90_perr(trim(myname_),trim(msg),-1)
-         stop -3
+         stop 99002
       endif
       call i90_LoadF(trim(fileModelConf), iret)
       if(iret.ne.0)then
          write(msg,'(3A)')'i90_LoadF("',trim(fileModelConf),'")'
          call i90_perr(trim(myname_),trim(msg),iret)
-         stop -4
+         stop 99003
       endif
 
 #ifdef DEBUG
@@ -430,19 +430,19 @@ Contains
     call i90_label(trim(label),ierr)
     if(ierr.ne.0)then
        call i90_perr(trim(myname_),'i90_label( '//trim(label)//' ... )', ierr)
-       stop -5
+       stop 99004
     endif
 
     GDef%num = i90_Gint(ierr)
     if(ierr.ne.0)then
        call i90_perr(trim(myname_),'i90_Gint( '//trim(label)//'%num ... )', ierr)
-       stop -6
+       stop 99005
     endif
 
     call i90_GToken(GDef%mapping,ierr)
     if(ierr.ne.0)then
        call i90_perr(trim(myname_),'i90_GToken( '//trim(label)//'%mapping ... )', ierr)
-       stop -7
+       stop 99006
     endif
 
     select case (trim(i90_lcase(GDef%mapping)))
@@ -452,25 +452,25 @@ Contains
        Gdef%start_coord = i90_GFloat(ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'i90_GFloat( '//trim(label)//'%start_coord ... )', ierr)
-          stop -8
+          stop 99007
        endif
 
        Gdef%incr_coord = i90_GFloat(ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'i90_GFloat( '//trim(label)//'%incr_coord ... )', ierr)
-          stop -9
+          stop 99008
        endif
 
        allocate(GDef%coord(GDef%num),stat=ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'Allocate( '//trim(label)//'%coord(:) ... )', ierr)
-          stop -10
+          stop 99009
        endif
 
        call GetLinCoords(GDef%start_coord, GDef%incr_coord, GDef%num, GDef%coord, ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'GetLinCoords( '//trim(label)//' ... )', ierr)
-          stop -11
+          stop 99010
        endif
 
     case('levels')
@@ -480,13 +480,13 @@ Contains
        allocate(GDef%coord(GDef%num),stat=ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'Allocate( '//trim(label)//'%coord(:) ... )', ierr)
-          stop -12
+          stop 99011
        endif
 
        call GetLevelsCoord( GDef%num, GDef%coord, ierr )
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'GetLevelsCoords( '//trim(label)//' ... )', ierr)
-          stop -13
+          stop 99012
        endif
 
        GDef%start_coord = GDef%coord(1)

--- a/core/scan_ModelPlugin.f90
+++ b/core/scan_ModelPlugin.f90
@@ -196,13 +196,13 @@ Contains
       if(.not.found)then
          write(msg,'(2A)')'File not found :', trim(fileModelConf)
          call i90_perr(trim(myname_),trim(msg),-1)
-         stop
+         stop -3
       endif
       call i90_LoadF(trim(fileModelConf), iret)
       if(iret.ne.0)then
          write(msg,'(3A)')'i90_LoadF("',trim(fileModelConf),'")'
          call i90_perr(trim(myname_),trim(msg),iret)
-         stop
+         stop -4
       endif
 
 #ifdef DEBUG
@@ -430,19 +430,19 @@ Contains
     call i90_label(trim(label),ierr)
     if(ierr.ne.0)then
        call i90_perr(trim(myname_),'i90_label( '//trim(label)//' ... )', ierr)
-       stop
+       stop -5
     endif
 
     GDef%num = i90_Gint(ierr)
     if(ierr.ne.0)then
        call i90_perr(trim(myname_),'i90_Gint( '//trim(label)//'%num ... )', ierr)
-       stop
+       stop -6
     endif
 
     call i90_GToken(GDef%mapping,ierr)
     if(ierr.ne.0)then
        call i90_perr(trim(myname_),'i90_GToken( '//trim(label)//'%mapping ... )', ierr)
-       stop
+       stop -7
     endif
 
     select case (trim(i90_lcase(GDef%mapping)))
@@ -452,25 +452,25 @@ Contains
        Gdef%start_coord = i90_GFloat(ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'i90_GFloat( '//trim(label)//'%start_coord ... )', ierr)
-          stop
+          stop -8
        endif
 
        Gdef%incr_coord = i90_GFloat(ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'i90_GFloat( '//trim(label)//'%incr_coord ... )', ierr)
-          stop
+          stop -9
        endif
 
        allocate(GDef%coord(GDef%num),stat=ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'Allocate( '//trim(label)//'%coord(:) ... )', ierr)
-          stop
+          stop -10
        endif
 
        call GetLinCoords(GDef%start_coord, GDef%incr_coord, GDef%num, GDef%coord, ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'GetLinCoords( '//trim(label)//' ... )', ierr)
-          stop
+          stop -11
        endif
 
     case('levels')
@@ -480,13 +480,13 @@ Contains
        allocate(GDef%coord(GDef%num),stat=ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'Allocate( '//trim(label)//'%coord(:) ... )', ierr)
-          stop
+          stop -12
        endif
 
        call GetLevelsCoord( GDef%num, GDef%coord, ierr )
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'GetLevelsCoords( '//trim(label)//' ... )', ierr)
-          stop
+          stop -13
        endif
 
        GDef%start_coord = GDef%coord(1)

--- a/core/scan_UtilsMOD.f90
+++ b/core/scan_UtilsMOD.f90
@@ -206,7 +206,8 @@ MODULE scan_Utils
          if(iret /= 0) then
             call i90_perr(myname_,'i90_LoadF("'//trim(config)//'")',iret)
              if(present(istat))istat=iret
-            return
+            !return
+            stop 99038
          endif
 !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/core/scan_coreMOD.f90
+++ b/core/scan_coreMOD.f90
@@ -133,7 +133,7 @@ CONTAINS
     ! Sanity Check
     if (scantec%atime_step .gt. scantec%ftime_step)then
        write(stdout,*)'ERROR: Analisys Time Step should be less or equal to Forecast Time Step'
-       stop
+       stop -1
     endif
 
     scantec%hist_incr      = real(scantec%hist_time/24.0d0)

--- a/core/scan_coreMOD.f90
+++ b/core/scan_coreMOD.f90
@@ -133,7 +133,7 @@ CONTAINS
     ! Sanity Check
     if (scantec%atime_step .gt. scantec%ftime_step)then
        write(stdout,*)'ERROR: Analisys Time Step should be less or equal to Forecast Time Step'
-       stop -1
+       stop 99000
     endif
 
     scantec%hist_incr      = real(scantec%hist_time/24.0d0)

--- a/core/scan_dataMOD.f90
+++ b/core/scan_dataMOD.f90
@@ -139,7 +139,7 @@ CONTAINS
     if(iret.ne.0)then
        write(msg,'(3A)')'i90_LoadF("',trim(scanVarsConf),'")'
        call i90_perr(trim(myname_),trim(msg),iret)
-       stop
+       stop -2
     endif
 
     call i90_label('variables:',iret)

--- a/core/scan_dataMOD.f90
+++ b/core/scan_dataMOD.f90
@@ -139,7 +139,7 @@ CONTAINS
     if(iret.ne.0)then
        write(msg,'(3A)')'i90_LoadF("',trim(scanVarsConf),'")'
        call i90_perr(trim(myname_),trim(msg),iret)
-       stop -2
+       stop 99001
     endif
 
     call i90_label('variables:',iret)

--- a/core/scan_readModel.f90
+++ b/core/scan_readModel.f90
@@ -123,13 +123,13 @@ module scan_readModel
       if(.not.found)then
          write(msg,'(2A)')'File not found :', trim(fileModelConf)
          call i90_perr(trim(myname_),trim(msg),-1)
-         stop
+         stop -14
       endif
       call i90_LoadF(trim(fileModelConf), iret)
       if(iret.ne.0)then
          write(msg,'(3A)')'i90_LoadF("',trim(fileModelConf),'")'
          call i90_perr(trim(myname_),trim(msg),iret)
-         stop
+         stop -15
       endif
 
 #ifdef DEBUG
@@ -334,19 +334,19 @@ module scan_readModel
     call i90_label(trim(label),ierr)
     if(ierr.ne.0)then
        call i90_perr(trim(myname_),'i90_label( '//trim(label)//' ... )', ierr)
-       stop
+       stop -16
     endif
 
     GDef%num = i90_Gint(ierr)
     if(ierr.ne.0)then
        call i90_perr(trim(myname_),'i90_Gint( '//trim(label)//'%num ... )', ierr)
-       stop
+       stop -17
     endif
 
     call i90_GToken(GDef%mapping,ierr)
     if(ierr.ne.0)then
        call i90_perr(trim(myname_),'i90_GToken( '//trim(label)//'%mapping ... )', ierr)
-       stop
+       stop -18
     endif
 
     select case (trim(i90_lcase(GDef%mapping)))
@@ -356,25 +356,25 @@ module scan_readModel
        Gdef%start_coord = i90_GFloat(ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'i90_GFloat( '//trim(label)//'%start_coord ... )', ierr)
-          stop
+          stop -19
        endif
 
        Gdef%incr_coord = i90_GFloat(ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'i90_GFloat( '//trim(label)//'%incr_coord ... )', ierr)
-          stop
+          stop -20
        endif
 
        allocate(GDef%coord(GDef%num),stat=ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'Allocate( '//trim(label)//'%coord(:) ... )', ierr)
-          stop
+          stop -21
        endif
 
        call GetLinCoords(GDef%start_coord, GDef%incr_coord, GDef%num, GDef%coord, ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'GetLinCoords( '//trim(label)//' ... )', ierr)
-          stop
+          stop -22
        endif
 
     case('levels')
@@ -384,13 +384,13 @@ module scan_readModel
        allocate(GDef%coord(GDef%num),stat=ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'Allocate( '//trim(label)//'%coord(:) ... )', ierr)
-          stop
+          stop -23
        endif
 
        call GetLevelsCoord( GDef%num, GDef%coord, ierr )
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'GetLevelsCoords( '//trim(label)//' ... )', ierr)
-          stop
+          stop -24
        endif
 
        GDef%start_coord = GDef%coord(1)

--- a/core/scan_readModel.f90
+++ b/core/scan_readModel.f90
@@ -123,13 +123,13 @@ module scan_readModel
       if(.not.found)then
          write(msg,'(2A)')'File not found :', trim(fileModelConf)
          call i90_perr(trim(myname_),trim(msg),-1)
-         stop -14
+         stop 99013
       endif
       call i90_LoadF(trim(fileModelConf), iret)
       if(iret.ne.0)then
          write(msg,'(3A)')'i90_LoadF("',trim(fileModelConf),'")'
          call i90_perr(trim(myname_),trim(msg),iret)
-         stop -15
+         stop 99014
       endif
 
 #ifdef DEBUG
@@ -334,19 +334,19 @@ module scan_readModel
     call i90_label(trim(label),ierr)
     if(ierr.ne.0)then
        call i90_perr(trim(myname_),'i90_label( '//trim(label)//' ... )', ierr)
-       stop -16
+       stop 99015
     endif
 
     GDef%num = i90_Gint(ierr)
     if(ierr.ne.0)then
        call i90_perr(trim(myname_),'i90_Gint( '//trim(label)//'%num ... )', ierr)
-       stop -17
+       stop 99016
     endif
 
     call i90_GToken(GDef%mapping,ierr)
     if(ierr.ne.0)then
        call i90_perr(trim(myname_),'i90_GToken( '//trim(label)//'%mapping ... )', ierr)
-       stop -18
+       stop 99017
     endif
 
     select case (trim(i90_lcase(GDef%mapping)))
@@ -356,25 +356,25 @@ module scan_readModel
        Gdef%start_coord = i90_GFloat(ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'i90_GFloat( '//trim(label)//'%start_coord ... )', ierr)
-          stop -19
+          stop 99018
        endif
 
        Gdef%incr_coord = i90_GFloat(ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'i90_GFloat( '//trim(label)//'%incr_coord ... )', ierr)
-          stop -20
+          stop 99019
        endif
 
        allocate(GDef%coord(GDef%num),stat=ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'Allocate( '//trim(label)//'%coord(:) ... )', ierr)
-          stop -21
+          stop 99020
        endif
 
        call GetLinCoords(GDef%start_coord, GDef%incr_coord, GDef%num, GDef%coord, ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'GetLinCoords( '//trim(label)//' ... )', ierr)
-          stop -22
+          stop 99021
        endif
 
     case('levels')
@@ -384,13 +384,13 @@ module scan_readModel
        allocate(GDef%coord(GDef%num),stat=ierr)
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'Allocate( '//trim(label)//'%coord(:) ... )', ierr)
-          stop -23
+          stop 99022
        endif
 
        call GetLevelsCoord( GDef%num, GDef%coord, ierr )
        if(ierr.ne.0)then
           call i90_perr(trim(myname_),'GetLevelsCoords( '//trim(label)//' ... )', ierr)
-          stop -24
+          stop 99023
        endif
 
        GDef%start_coord = GDef%coord(1)

--- a/core/scantec_module.f90
+++ b/core/scantec_module.f90
@@ -211,7 +211,7 @@ contains
 
     write(stdout,'(A,3(1x,A))')'Model Name or Model Type not found!',&
          trim(MType_),'->',trim(MName_)
-    stop -25
+    stop 99024
 
   end function getModel_
 
@@ -236,7 +236,7 @@ contains
        istat = -1
     else
        write(stdout,'(A,1x,A)') 'unknow Experient Name',trim(ExpName)
-       stop -26
+       stop 99025
     endif
   end subroutine getField_
 
@@ -263,7 +263,7 @@ contains
        istat = -1
     else
        write(stdout,'(A,1x,A)')'unknow Experiment Name',trim(ExpName)
-       stop -27
+       stop 99026
     endif
   end subroutine getBitMap_
 
@@ -323,7 +323,7 @@ contains
     enddo
     write(stdout,'(A,1x,2A,1x,A)')'Dimension not found in',&
          trim(self%Name_),'.model :',trim(mdim)
-    stop -28
+    stop 99027
 
   end function getDimVec_
 

--- a/core/scantec_module.f90
+++ b/core/scantec_module.f90
@@ -211,7 +211,7 @@ contains
 
     write(stdout,'(A,3(1x,A))')'Model Name or Model Type not found!',&
          trim(MType_),'->',trim(MName_)
-    stop
+    stop -25
 
   end function getModel_
 
@@ -236,7 +236,7 @@ contains
        istat = -1
     else
        write(stdout,'(A,1x,A)') 'unknow Experient Name',trim(ExpName)
-       stop
+       stop -26
     endif
   end subroutine getField_
 
@@ -263,7 +263,7 @@ contains
        istat = -1
     else
        write(stdout,'(A,1x,A)')'unknow Experiment Name',trim(ExpName)
-       stop
+       stop -27
     endif
   end subroutine getBitMap_
 
@@ -323,7 +323,7 @@ contains
     enddo
     write(stdout,'(A,1x,2A,1x,A)')'Dimension not found in',&
          trim(self%Name_),'.model :',trim(mdim)
-    stop
+    stop -28
 
   end function getDimVec_
 

--- a/core/varType.f90
+++ b/core/varType.f90
@@ -124,7 +124,7 @@ module varType
             value_ =  ref%value_
          class default
             print*, 'ERROR: wrong type, should be of `scalar` type '
-            stop
+            stop -29
          end select
 
       end subroutine
@@ -161,7 +161,7 @@ module varType
             enddo
          class default
             print*, 'ERROR: wrong type, should be of `array1D` type '
-            stop
+            stop -30
          end select
 
       end subroutine
@@ -182,7 +182,7 @@ module varType
             return_value = ref%value_
          class default
             print*, 'ERROR: wrong type, should be of `array1D` type '
-            stop
+            stop -31
          end select
 
       end subroutine
@@ -203,7 +203,7 @@ module varType
             return_value = ref%value_
          class default
             print*, 'ERROR: wrong type, should be of `array1D` type '
-            stop
+            stop -32
          end select
 
       end subroutine

--- a/core/varType.f90
+++ b/core/varType.f90
@@ -124,7 +124,7 @@ module varType
             value_ =  ref%value_
          class default
             print*, 'ERROR: wrong type, should be of `scalar` type '
-            stop -29
+            stop 99028
          end select
 
       end subroutine
@@ -161,7 +161,7 @@ module varType
             enddo
          class default
             print*, 'ERROR: wrong type, should be of `array1D` type '
-            stop -30
+            stop 99029
          end select
 
       end subroutine
@@ -182,7 +182,7 @@ module varType
             return_value = ref%value_
          class default
             print*, 'ERROR: wrong type, should be of `array1D` type '
-            stop -31
+            stop 99030
          end select
 
       end subroutine
@@ -203,7 +203,7 @@ module varType
             return_value = ref%value_
          class default
             print*, 'ERROR: wrong type, should be of `array1D` type '
-            stop -32
+            stop 99031
          end select
 
       end subroutine


### PR DESCRIPTION
Neste PR são propostas modificações no SCANTEC para que sejam emitidos códigos de insterrupção do código. Na issue #4, consta uma tabela (que será adicionada ao manual de uso do SCANTEC) para que seja possível identificar os códigos a partir do comando `echo $?`. Essas modificações visam atender à solicitação do @Garcia-INPE para uso do SCANTEC com o ECFLOW.