### PR TITLE
Issue #8: atualizando os arquivos core/Makefile, lib/BilinInterp/Make…

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -109,8 +109,8 @@ endif
 ifeq ($(SCAN_ARCH),GNU_Linux)
    FPP = gcc
    CC  = gcc
-   FC  = gfortran-9
-   LD  = gfortran-9
+   FC  = gfortran
+   LD  = gfortran
    AR  = ar
 #   FFLAGS += -cpp -frecursive -ffree-line-length-none -Dgfortran
    FFLAGS += -cpp -ffree-line-length-none -Dgfortran 

--- a/lib/BilinInterp/Makefile
+++ b/lib/BilinInterp/Makefile
@@ -88,8 +88,8 @@ endif
 #
 
 ifeq ($(SCAN_ARCH),GNU_Linux)
-   FC  = gfortran-9
-   LD  = gfortran-9
+   FC  = gfortran
+   LD  = gfortran
    FFLAGS += -ffree-line-length-none
 
 # add flags for debugging if requested

--- a/lib/w3lib-2.0.6/Makefile
+++ b/lib/w3lib-2.0.6/Makefile
@@ -22,7 +22,7 @@ ARFLAGS = r
 endif
 
 ifeq ($(SCAN_ARCH),GNU_Linux)
- F77     = gfortran-9
+ F77     = gfortran
  FFLAGS  = 
  CFLAGS  = -O -DLINUX
  CC      = gcc


### PR DESCRIPTION
Neste PR, são atualizados os arquivos Makefiles que estavam utilizando o compilador GNU com o nome `gfortran-9`. O nome do compilador foi atualizado para `gfortran`.